### PR TITLE
Add scripts for quality of dev life

### DIFF
--- a/UtilityScripts/DebugAOS.ps1
+++ b/UtilityScripts/DebugAOS.ps1
@@ -1,0 +1,32 @@
+# Path to your local repository
+$repoDirectory = "E:\Repos\AOS"
+# Path to your emulator directory
+$emulatorDirectory = "C:\MyUser\AppData\Local\Android\Sdk\tools"
+
+$switchToRepoDirectoryCommand = "cd '$repoDirectory'"
+$switchToEmulatorDirectoryCommand = "cd '$emulatorDirectory'"
+$startExpoAppLocalDebugCommand = "npx expo start --lan"
+$startEmulatorCommand = ".\emulator -avd Pixel_6_Pro_API_33"
+
+function Open-Emulator {
+    $commands = "$switchToEmulatorDirectoryCommand; $startEmulatorCommand"
+    Start-Process powershell -ArgumentList "-NoExit","-Command $commands"
+}
+
+function Open-ExpoApp {
+    $commands = "$switchToRepoDirectoryCommand; $startExpoAppLocalDebugCommand"
+    Start-Process powershell -ArgumentList "-NoExit","-Command $commands"
+}
+
+function Open-ReactNativeDebugger {
+    Start-Process powershell -ArgumentList "-NoExit","-Command react-devtools"
+}
+
+function Open-RepoDirectory {
+    Start-Process powershell -ArgumentList "-NoExit","-Command $switchToRepoDirectoryCommand"
+}
+
+Open-Emulator
+Open-ExpoApp
+Open-ReactNativeDebugger
+Open-RepoDirectory

--- a/UtilityScripts/UpdateFromFork.ps1
+++ b/UtilityScripts/UpdateFromFork.ps1
@@ -1,0 +1,25 @@
+# Set the paths and repository URLs
+$mainRepoUrl = "https://github.com/1hitsong/AOS.git"
+# Your local repository path
+$forkedRepoPath = "E:\Repos\AOS" 
+
+# Change directory to the forked repository
+Set-Location -Path $forkedRepoPath
+
+# Add the main repository as an upstream remote
+git remote add upstream $mainRepoUrl
+
+# Fetch the latest changes from the main repository
+git fetch upstream
+
+# Merge the fetched changes into your local branch
+git merge upstream/master
+
+# Push the updated branch to your forked repository on GitHub
+git push origin master
+
+# Clean up by removing the upstream remote
+git remote remove upstream
+
+# Output a success message
+Write-Host "Forked repository updated successfully!"


### PR DESCRIPTION
This is adding two scripts to aid in contributing to the project. The first script aids in debugging locally. It performs the following actions:
* Runs the expo project set up for local debugging
* Starts an Android emulator on the local machine
* Starts React Devtools
* Opens a terminal in the location of the local repository

The second script will update a local fork of the original AOS repository. Both of these scripts are Powershell scripts.